### PR TITLE
fix: Erro to build with make

### DIFF
--- a/main.c
+++ b/main.c
@@ -19,6 +19,7 @@
  * THE SOFTWARE
  */
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Fix error with make build:

error: implicit declaration of function ‘isxdigit’ [-Wimplicit-function-declaration]
   68 |         if (!isxdigit(*p) || !isxdigit(*(p+1))) {
      |              ^~~~~~~~